### PR TITLE
Example constructor updates

### DIFF
--- a/example/audio-clip.js
+++ b/example/audio-clip.js
@@ -1,8 +1,12 @@
 import { FrameMsg, StdLua, RxAudio, TxCode, RxAudioSampleRate, RxAudioBitDepth } from 'frame-msg';
 import frameApp from './lua/audio_clip_frame_app.lua?raw';
 
-// Record an audio clip using Frame's microphone and play it back
-// This example uses the RxAudio class to receive audio data from Frame
+/**
+ * Demonstrates how to record an audio clip using Frame's microphone and play it back.
+ * This example utilizes the RxAudio class to receive audio data from the Frame device
+ * in non-streaming mode, then converts the raw PCM data to WAV format for playback
+ * using the Web Audio API.
+ */
 export async function run() {
   const frame = new FrameMsg();
 
@@ -42,7 +46,7 @@ export async function run() {
 
     // Tell Frame to start streaming audio
     // Assuming 0x30 is the correct message ID and new TxCode(1).pack() is the start command
-    await frame.sendMessage(0x30, new TxCode(1).pack());
+    await frame.sendMessage(0x30, new TxCode({ value: 1 }).pack());
 
     console.log("Recording audio for 10 seconds...");
     await new Promise(resolve => setTimeout(resolve, 10000));
@@ -50,7 +54,7 @@ export async function run() {
     // Stop the audio stream
     console.log("Stopping audio...");
     // Assuming new TxCode(0).pack() is the stop command
-    await frame.sendMessage(0x30, new TxCode(0).pack());
+    await frame.sendMessage(0x30, new TxCode({ value: 0 }).pack());
 
     // Get the raw PCM audio data from RxAudio
     // RxAudio (non-streaming) puts the complete audio data first, then null

--- a/example/audio-stream.js
+++ b/example/audio-stream.js
@@ -57,6 +57,13 @@ class PCMPlayerProcessor extends AudioWorkletProcessor {
 registerProcessor('pcm-player-processor', PCMPlayerProcessor);
 `;
 
+/**
+ * Demonstrates streaming audio data from a Frame device and playing it in real-time.
+ * This example uses the RxAudio class in streaming mode to receive audio chunks
+ * (either 8-bit or 16-bit PCM). These chunks are then converted to Float32Array
+ * and sent to a custom AudioWorkletProcessor for playback via the Web Audio API.
+ * The stream runs for a fixed duration before automatically stopping and cleaning up.
+ */
 export async function run() {
     const frame = new FrameMsg();
     let audioContext;
@@ -105,7 +112,7 @@ export async function run() {
 
         // 3. Tell Frame to start sending audio data
         console.log("Requesting Frame to start audio stream...");
-        await frame.sendMessage(0x30, new TxCode(1).pack()); // Start audio command
+        await frame.sendMessage(0x30, new TxCode({ value: 1 }).pack()); // Start audio command
 
         console.log("Audio streaming started. Listening for data...");
 
@@ -155,7 +162,7 @@ export async function run() {
         if (frame.isConnected()) {
             try {
                 console.log("Requesting Frame to stop audio stream...");
-                await frame.sendMessage(0x30, new TxCode(0).pack()); // Stop audio command
+                await frame.sendMessage(0x30, new TxCode({ value: 0 }).pack()); // Stop audio command
             } catch (e) {
                 console.error("Error sending stop stream command to Frame:", e);
             }

--- a/example/audio-video-stream.js
+++ b/example/audio-video-stream.js
@@ -111,7 +111,7 @@ async function runPhotoProcessing(frame, photoQueue, getKeepRunning, photoInterv
         if (!getKeepRunning() || !frame.isConnected()) return false;
 
         console.log("Requesting photo...");
-        const captureSettings = new TxCaptureSettings();
+        const captureSettings = new TxCaptureSettings({});
         try {
             await frame.sendMessage(0x0d, captureSettings.pack());
             lastPhotoRequestTimeMs = Date.now();
@@ -211,6 +211,16 @@ async function runPhotoProcessing(frame, photoQueue, getKeepRunning, photoInterv
 // --- Main application ---
 let imageDisplayElement = null; // Single image element for display
 
+/**
+ * Demonstrates simultaneously streaming audio and periodically capturing photos from a Frame device.
+ * This example utilizes:
+ * - `RxAudio` for receiving and processing streaming audio data.
+ * - `RxPhoto` for capturing and receiving photo data.
+ * - The Web Audio API with a custom `AudioWorkletProcessor` for real-time audio playback.
+ * - Dynamic HTML image element updates to display the latest captured photo.
+ * It also includes robust handling for starting, stopping, and cleaning up resources
+ * for both audio and photo streams, including device connection and application lifecycle.
+ */
 export async function run() {
     const frame = new FrameMsg();
     let audioContext;
@@ -275,7 +285,7 @@ export async function run() {
         };
 
         console.log("Requesting Frame to start audio stream...");
-        await frame.sendMessage(0x30, new TxCode(1).pack());
+        await frame.sendMessage(0x30, new TxCode({ value: 1 }).pack());
 
         // Start asynchronous processing loops
         const audioProcessingPromise = runAudioProcessing(frame, audioQueue, pcmPlayerNode, getKeepRunning, signalShutdown, rxAudio);
@@ -299,7 +309,7 @@ export async function run() {
         await new Promise(resolve => setTimeout(resolve, 20000));
 
         console.log("Requesting Frame to stop audio stream...");
-        await frame.sendMessage(0x30, new TxCode(0).pack());
+        await frame.sendMessage(0x30, new TxCode({ value: 0 }).pack());
 
         await shutdownPromise; // Wait until shutdown is signaled
 
@@ -327,7 +337,7 @@ export async function run() {
         if (frame && frame.isConnected()) {
             try {
                 console.log("Requesting Frame to stop audio stream...");
-                await frame.sendMessage(0x30, new TxCode(0).pack());
+                await frame.sendMessage(0x30, new TxCode({ value: 0 }).pack());
             } catch (e) {
                 console.error("Error sending stop audio command to Frame:", e);
             }

--- a/example/auto-exposure.js
+++ b/example/auto-exposure.js
@@ -1,7 +1,15 @@
 import { FrameMsg, StdLua, TxCaptureSettings, TxAutoExpSettings, RxPhoto, RxAutoExpResult, TxCode } from 'frame-msg';
 import frameApp from './lua/auto_exposure_frame_app.lua?raw';
 
-// Take a sequence of photos using the Frame camera with custom auto exposure settings and display it
+/**
+ * Demonstrates taking a sequence of photos using the Frame camera with custom auto exposure settings.
+ * This example showcases:
+ * - Setting initial auto exposure parameters using `TxAutoExpSettings`.
+ * - Receiving detailed auto exposure algorithm outputs via `RxAutoExpResult`.
+ * - Iteratively triggering single steps of the auto exposure algorithm on the Frame device.
+ * - Capturing photos after each step using `TxCaptureSettings` to request the image and `RxPhoto` to receive it.
+ * - Displaying the captured photos on a web page.
+ */
 export async function run() {
   const frame = new FrameMsg();
 
@@ -45,7 +53,7 @@ export async function run() {
 
     // take the default auto exposure settings
     // and send them to Frame before iterating over the auto exposure steps
-    await frame.sendMessage(0x0e, new TxAutoExpSettings().pack());
+    await frame.sendMessage(0x0e, new TxAutoExpSettings({}).pack());
 
     // create the element to display the photo
     const img = document.createElement('img');
@@ -61,7 +69,7 @@ export async function run() {
     // Iterate 20 times
     for (let i = 0; i < 20; i++) {
       // send the code to trigger the single step of the auto exposure algorithm
-      await frame.sendMessage(0x0f, new TxCode().pack());
+      await frame.sendMessage(0x0f, new TxCode({}).pack());
 
       // receive the auto exposure output from Frame
       const autoExpResult = await autoExpQueue.get();
@@ -71,8 +79,7 @@ export async function run() {
       await new Promise(resolve => setTimeout(resolve, 200));
 
       // Request the photo by sending a TxCaptureSettings message
-      // TODO should I use the {options} style for constructor parameters?
-      await frame.sendMessage(0x0d, new TxCaptureSettings().pack());
+      await frame.sendMessage(0x0d, new TxCaptureSettings({}).pack());
 
       // get the jpeg bytes as soon as they're ready
       const jpegBytes = await photoQueue.get();

--- a/example/camera-sprite.js
+++ b/example/camera-sprite.js
@@ -17,7 +17,16 @@ function displayImage(imageBytes, mimeType, divId) {
   }
 }
 
-// Take a photo using the Frame camera, send it to the host, and send it back as a sprite (TxImageSpriteBlock) to the Frame display
+/**
+ * Demonstrates a round-trip image manipulation workflow with a Frame device.
+ * This example involves:
+ * 1. Capturing a photo from the Frame camera using `TxCaptureSettings` to initiate and `RxPhoto` to receive the image data.
+ * 2. Displaying this original photo on the webpage.
+ * 3. Converting the received JPEG photo into a `TxSprite` using `TxSprite.fromImageBytes`, which involves resizing and color quantization.
+ * 4. Displaying the generated sprite (as a PNG) on the webpage for comparison.
+ * 5. Creating a `TxImageSpriteBlock` from this `TxSprite`, which splits the sprite into smaller, transmittable lines.
+ * 6. Sending this `TxImageSpriteBlock` (header first, then each sprite line) back to the Frame device for display on its screen.
+ */
 export async function run() {
   const frame = new FrameMsg();
 
@@ -61,7 +70,7 @@ export async function run() {
     console.log("Taking photo...");
 
     // Request the photo by sending a TxCaptureSettings message
-    await frame.sendMessage(0x0d, new TxCaptureSettings().pack());
+    await frame.sendMessage(0x0d, new TxCaptureSettings({}).pack());
 
     // get the jpeg bytes as soon as they're ready
     const jpegBytes = await photoQueue.get();
@@ -77,7 +86,7 @@ export async function run() {
     // display the sprite on the web page
     displayImage(sprite.toPngBytes(), 'image/png', 'image2');
 
-    const isb = new TxImageSpriteBlock(sprite, 20);
+    const isb = new TxImageSpriteBlock({ image: sprite, spriteLineHeight: 20 });
     // send the Image Sprite Block header
     await frame.sendMessage(0x20, isb.pack());
 

--- a/example/camera.js
+++ b/example/camera.js
@@ -1,7 +1,13 @@
 import { FrameMsg, StdLua, TxCaptureSettings, RxPhoto } from 'frame-msg';
 import frameApp from './lua/camera_frame_app.lua?raw';
 
-// Take a photo using the Frame camera and display it
+/**
+ * Demonstrates how to take a photo using the Frame camera and display it on a webpage.
+ * This example involves:
+ * - Sending `TxCaptureSettings` to the Frame device to request a photo.
+ * - Using `RxPhoto` to receive the JPEG image data from the Frame.
+ * - Displaying the captured photo within an HTML image element on the webpage.
+ */
 export async function run() {
   const frame = new FrameMsg();
 
@@ -45,7 +51,7 @@ export async function run() {
     console.log("Taking photo...");
 
     // Request the photo by sending a TxCaptureSettings message
-    await frame.sendMessage(0x0d, new TxCaptureSettings().pack());
+    await frame.sendMessage(0x0d, new TxCaptureSettings({}).pack());
 
     // get the jpeg bytes as soon as they're ready
     const jpegBytes = await photoQueue.get();

--- a/example/code-value.js
+++ b/example/code-value.js
@@ -1,7 +1,13 @@
 import { FrameMsg, StdLua, TxCode } from 'frame-msg';
 import frameApp from './lua/code_value_frame_app.lua?raw';
 
-// Send a tiny TxCode message to Frame with a single-byte value as a control message
+/**
+ * Demonstrates sending a sequence of `TxCode` messages to a Frame device.
+ * Each `TxCode` message carries a single-byte value, which is iteratively updated.
+ * The corresponding Frame Lua application (`code_value_frame_app.lua`) is expected
+ * to receive these messages and print the contained value to its standard output.
+ * This example showcases a basic control message pattern.
+ */
 export async function run() {
   const frame = new FrameMsg();
 
@@ -37,7 +43,7 @@ export async function run() {
 
     // iterate 10 times and sleep for 1 second between each iteration
     for (let i = 1; i <= 10; i++) {
-      await frame.sendMessage(0x42, new TxCode(i).pack());
+      await frame.sendMessage(0x42, new TxCode({ value: i }).pack());
       await new Promise(resolve => setTimeout(resolve, 1000));
     }
 

--- a/example/imu-stream.js
+++ b/example/imu-stream.js
@@ -1,7 +1,15 @@
 import { FrameMsg, StdLua, TxCode, RxIMU } from 'frame-msg';
 import frameApp from './lua/imu_stream_frame_app.lua?raw';
 
-// Stream IMU updates from Frame and print them to the console
+/**
+ * Demonstrates streaming Inertial Measurement Unit (IMU) data from a Frame device.
+ * This example involves:
+ * - Sending `TxCode` messages to start and stop the IMU data stream on the Frame device.
+ * - Using `RxIMU` to receive IMU data, which includes compass and accelerometer readings.
+ * - Calculating pitch and roll from the accelerometer data.
+ * - Displaying the raw compass, accelerometer, and calculated pitch/roll values on the webpage.
+ * - Printing the received IMU data objects to the console.
+ */
 export async function run() {
   const frame = new FrameMsg();
 
@@ -41,7 +49,7 @@ export async function run() {
 
     // Start the IMU updates
     console.log("Starting IMU stream...");
-    await frame.sendMessage(0x40, new TxCode(1).pack());
+    await frame.sendMessage(0x40, new TxCode({ value: 1 }).pack());
 
     // find the element to display the IMU data
     const imuDataDiv = document.getElementById('text1');
@@ -70,7 +78,7 @@ export async function run() {
     }
 
     console.log("Stopping IMU stream...");
-    await frame.sendMessage(0x40, new TxCode(0).pack());
+    await frame.sendMessage(0x40, new TxCode({ value: 0 }).pack());
 
     // stop the listener and clean up its resources
     rxIMU.detach(frame);

--- a/example/live-camera-feed.js
+++ b/example/live-camera-feed.js
@@ -1,7 +1,14 @@
 import { FrameMsg, StdLua, TxCaptureSettings, RxPhoto } from 'frame-msg';
 import frameApp from './lua/live_camera_feed_frame_app.lua?raw';
 
-// Take a sequence of photos using the Frame camera and display them
+/**
+ * Demonstrates capturing a sequence of photos from the Frame camera and displaying them
+ * on a webpage to create a live feed effect.
+ * This example involves:
+ * - Iteratively requesting photos from the Frame device using `TxCaptureSettings`.
+ * - Receiving the JPEG image data via `RxPhoto`.
+ * - Displaying each newly captured photo in an HTML image element, replacing the previous one.
+ */
 export async function run() {
   const frame = new FrameMsg();
 
@@ -53,7 +60,7 @@ export async function run() {
     // loop 20 times - take a photo and display it in the div
     for (let i = 0; i < 20; i++) {
       // Request the photo by sending a TxCaptureSettings message
-      await frame.sendMessage(0x0d, new TxCaptureSettings().pack());
+      await frame.sendMessage(0x0d, new TxCaptureSettings({}).pack());
 
       // get the jpeg bytes as soon as they're ready
       const jpegBytes = await photoQueue.get();

--- a/example/manual-exposure.js
+++ b/example/manual-exposure.js
@@ -1,7 +1,14 @@
 import { FrameMsg, StdLua, TxCaptureSettings, TxManualExpSettings, RxPhoto } from 'frame-msg';
 import frameApp from './lua/manual_exposure_frame_app.lua?raw';
 
-// Take a photo using the Frame camera with manual exposure settings and display it
+/**
+ * Demonstrates taking a photo using the Frame camera with specific manual exposure settings.
+ * This example involves:
+ * - Sending `TxManualExpSettings` to the Frame device to configure parameters like shutter speed and gain.
+ * - Sending `TxCaptureSettings` to request the photo capture.
+ * - Using `RxPhoto` to receive the JPEG image data from the Frame.
+ * - Displaying the captured photo within an HTML image element on the webpage.
+ */
 export async function run() {
   const frame = new FrameMsg();
 
@@ -41,14 +48,14 @@ export async function run() {
 
     // take the default manual exposure settings
     // and send them to Frame before taking the photo
-    await frame.sendMessage(0x0c, new TxManualExpSettings().pack());
+    await frame.sendMessage(0x0c, new TxManualExpSettings({}).pack());
 
     // NOTE: it takes up to 200ms for manual camera settings to take effect!
     console.log("Waiting 200ms for manual exposure settings to take effect...");
     await new Promise(resolve => setTimeout(resolve, 200));
 
     // Request the photo by sending a TxCaptureSettings message
-    await frame.sendMessage(0x0d, new TxCaptureSettings().pack());
+    await frame.sendMessage(0x0d, new TxCaptureSettings({}).pack());
 
     // get the jpeg bytes as soon as they're ready
     const jpegBytes = await photoQueue.get();

--- a/example/metering-data.js
+++ b/example/metering-data.js
@@ -1,7 +1,14 @@
 import { FrameMsg, StdLua, TxCode, RxMeteringData } from 'frame-msg';
 import frameApp from './lua/metering_data_frame_app.lua?raw';
 
-// Request a sequence of light metering updates from Frame's camera and print them to the console
+/**
+ * Demonstrates requesting and displaying a sequence of light metering updates from Frame's camera.
+ * This example involves:
+ * - Sending `TxCode` messages to the Frame device to trigger light metering updates.
+ * - Using `RxMeteringData` to receive the metering data, which includes spot and matrix RGB values.
+ * - Displaying the received metering data (spot R,G,B and matrix R,G,B) on the webpage.
+ * - Printing the raw metering data objects to the console.
+ */
 export async function run() {
   const frame = new FrameMsg();
 
@@ -50,7 +57,7 @@ export async function run() {
 
     // loop 60 times - await for the metering data to be received then print it to the console
     for (let i = 0; i < 60; i++) {
-      await frame.sendMessage(0x12, new TxCode(1).pack());
+      await frame.sendMessage(0x12, new TxCode({ value: 1 }).pack());
       const data = await meteringDataQueue.get();
       console.log("Metering Data:", data);
 

--- a/example/multi-tap.js
+++ b/example/multi-tap.js
@@ -1,6 +1,13 @@
 import { FrameMsg, StdLua, TxCode, RxTap } from 'frame-msg';
 import frameApp from './lua/multi_tap_frame_app.lua?raw';
 
+/**
+ * Demonstrates detecting and counting multi-tap events from a Frame device.
+ * This example involves:
+ * - Sending `TxCode` messages to the Frame device to subscribe to and later unsubscribe from tap events.
+ * - Using `RxTap` to receive and process tap events, which counts consecutive taps within a defined threshold.
+ * - Logging the detected tap counts to the console (e.g., "2-tap received", "3-tap received").
+ */
 export async function run() {
   const frame = new FrameMsg();
 
@@ -35,11 +42,11 @@ export async function run() {
     await frame.startFrameApp();
 
     // hook up the RxTap receiver
-    var rxTap = new RxTap();
+    var rxTap = new RxTap({});
     var tapQueue = await rxTap.attach(frame);
 
     // Subscribe for tap events
-    await frame.sendMessage(0x10, new TxCode(1).pack());
+    await frame.sendMessage(0x10, new TxCode({ value: 1 }).pack());
 
     // iterate 10 times
     for (let i = 0; i < 10; i++) {
@@ -49,7 +56,7 @@ export async function run() {
     }
 
     // unsubscribe from tap events
-    await frame.sendMessage(0x10, new TxCode(0).pack());
+    await frame.sendMessage(0x10, new TxCode({ value: 0 }).pack());
 
     // stop the tap listener and clean up its resources
     rxTap.detach(frame);

--- a/example/plain-text.js
+++ b/example/plain-text.js
@@ -1,6 +1,14 @@
 import { FrameMsg, StdLua, TxPlainText } from 'frame-msg';
 import frameApp from './lua/plain_text_frame_app.lua?raw';
 
+/**
+ * Demonstrates sending a sequence of plain text messages to a Frame device for display.
+ * This example involves:
+ * - Iteratively creating `TxPlainText` messages with varying text content and palette offsets (for different colors).
+ * - Sending these messages to the Frame device, where a corresponding Lua application is expected to handle
+ *   their display on the screen.
+ * - Includes a delay between messages to allow each text to be visible.
+ */
 export async function run() {
   const frame = new FrameMsg();
 
@@ -38,11 +46,11 @@ export async function run() {
     // Note that the frameside app is expecting a message of type TxPlainText on msgCode 0x0a
     const displayStrings = ["white", "gray", "red", "pink", "dark\nbrown", "brown", "orange", "yellow", "dark\ngreen", "green", "light\ngreen", "night\nblue", "sea\nblue", "sky\nblue", "cloud\nblue"];
     for (let i = 0; i < displayStrings.length; i++) {
-      await frame.sendMessage(0x0a, new TxPlainText(displayStrings[i], 50, 50, i+1).pack());
+      await frame.sendMessage(0x0a, new TxPlainText({ text: displayStrings[i], x: 50, y: 50, paletteOffset: i+1 }).pack());
       await new Promise(resolve => setTimeout(resolve, 1000)); // 1 second delay
     }
     // clear the display
-    await frame.sendMessage(0x0a, new TxPlainText(" ").pack());
+    await frame.sendMessage(0x0a, new TxPlainText({ text: " " }).pack());
 
     // unhook the print handler
     frame.detachPrintResponseHandler()

--- a/example/prog-sprite-jpg.js
+++ b/example/prog-sprite-jpg.js
@@ -17,6 +17,20 @@ function displayImage(imageBytes, mimeType, divId) {
   }
 }
 
+/**
+ * Demonstrates fetching a JPG image, converting it to a sprite format,
+ * and sending it to a Frame device for progressive display.
+ * This example involves:
+ * - Fetching a JPG image from a local path.
+ * - Displaying the original JPG image on the webpage.
+ * - Converting the JPG image data into a `TxSprite` object using `TxSprite.fromImageBytes`,
+ *   which includes resizing and color quantization.
+ * - Displaying the generated `TxSprite` (as a PNG) on the webpage for comparison.
+ * - Creating a `TxImageSpriteBlock` from the `TxSprite`, configured for progressive rendering.
+ *   This process splits the sprite into smaller, transmittable lines.
+ * - Sending the `TxImageSpriteBlock` (header first, then each sprite line) to the Frame device,
+ *   allowing the image to be rendered progressively on its screen.
+ */
 export async function run() {
   const frame = new FrameMsg();
 
@@ -63,7 +77,7 @@ export async function run() {
     // display the sprite on the web page
     displayImage(sprite.toPngBytes(), 'image/png', 'image2');
 
-    const isb = new TxImageSpriteBlock(sprite, 20);
+    const isb = new TxImageSpriteBlock({ image: sprite, spriteLineHeight: 20 });
     // send the Image Sprite Block header
     await frame.sendMessage(0x20, isb.pack());
 

--- a/example/sprite-indexed-png.js
+++ b/example/sprite-indexed-png.js
@@ -1,6 +1,16 @@
 import { FrameMsg, StdLua, TxSprite } from 'frame-msg';
 import frameApp from './lua/sprite_indexed_png_frame_app.lua?raw';
 
+/**
+ * Demonstrates fetching and displaying various indexed PNG images on a Frame device.
+ * This example involves:
+ * - Fetching a sequence of indexed PNG images (specifically 1-bit, 2-bit, and 4-bit) from local paths.
+ * - Converting each fetched PNG image directly into a `TxSprite` object using `TxSprite.fromIndexedPngBytes`.
+ *   This method preserves the original indexed color data without further quantization or resizing.
+ * - Sending each `TxSprite` to the Frame device, where a corresponding Lua application is expected
+ *   to handle its display on the screen.
+ * - Pausing between sending each sprite to allow time for viewing on the Frame device.
+ */
 export async function run() {
   const frame = new FrameMsg();
 

--- a/example/sprite-jpg.js
+++ b/example/sprite-jpg.js
@@ -17,6 +17,18 @@ function displayImage(imageBytes, mimeType, divId) {
   }
 }
 
+/**
+ * Demonstrates fetching a JPG image, converting it to a `TxSprite`, and sending it to a Frame device.
+ * This example involves:
+ * - Fetching a JPG image from a local path.
+ * - Displaying the original JPG image on the webpage.
+ * - Converting the JPG image data into a `TxSprite` object using `TxSprite.fromImageBytes`.
+ *   This process includes resizing the image and quantizing its colors to a limited palette.
+ * - Sending the entire packed `TxSprite` (header, palette, and pixel data) to the Frame device
+ *   in a single message.
+ * - Displaying the generated `TxSprite` (as a PNG) on the webpage for comparison with the original.
+ * - The Frame device is expected to display the received sprite.
+ */
 export async function run() {
   const frame = new FrameMsg();
 

--- a/example/sprite-move.js
+++ b/example/sprite-move.js
@@ -1,6 +1,17 @@
 import { FrameMsg, StdLua, TxSprite, TxSpriteCoords, TxCode } from 'frame-msg';
 import frameApp from './lua/sprite_move_frame_app.lua?raw';
 
+/**
+ * Demonstrates sending a sprite to a Frame device and then moving it to random positions.
+ * This example involves:
+ * - Fetching an indexed PNG image and converting it to a `TxSprite` using `TxSprite.fromIndexedPngBytes`.
+ * - Sending this initial `TxSprite` to the Frame device.
+ * - Iteratively:
+ *   - Generating random X and Y coordinates.
+ *   - Sending these coordinates to the Frame device using a `TxSpriteCoords` message.
+ *   - Sending a `TxCode` message to trigger the Frame device to redraw the sprite at the new coordinates.
+ * - A short pause is included in each iteration to make the movement visible.
+ */
 export async function run() {
   const frame = new FrameMsg();
 
@@ -46,11 +57,11 @@ export async function run() {
     for (let i = 0; i < 20; i++) {
       const x = Math.floor(Math.random() * 441);
       const y = Math.floor(Math.random() * 201);
-      const coords = new TxSpriteCoords(0x20, x, y, 0);
+      const coords = new TxSpriteCoords({ code: 0x20, x: x, y: y, offset: 0 });
       await frame.sendMessage(0x40, coords.pack());
 
       // draw the sprite
-      await frame.sendMessage(0x50, new TxCode().pack());
+      await frame.sendMessage(0x50, new TxCode({}).pack());
 
       // sleep for 1s to allow the user to see the image
       await new Promise(resolve => setTimeout(resolve, 1000));

--- a/src/async-queue.ts
+++ b/src/async-queue.ts
@@ -8,6 +8,10 @@ export class AsyncQueue<T> {
     private promises: Promise<T>[];
     private resolvers: ((value: T | PromiseLike<T>) => void)[];
 
+    /**
+     * Constructs a new AsyncQueue instance.
+     * Initializes an empty queue for storing promises and their resolvers.
+     */
     constructor() {
         this.promises = [];
         this.resolvers = [];
@@ -19,6 +23,12 @@ export class AsyncQueue<T> {
         }));
     }
 
+    /**
+     * Adds a value to the end of the queue.
+     * If there are pending `get` operations, this will resolve the oldest one.
+     * Otherwise, the value is stored until a `get` operation is called.
+     * @param value The value to add to the queue.
+     */
     put(value: T): void {
         if (!this.resolvers.length) {
             this.add();
@@ -29,6 +39,11 @@ export class AsyncQueue<T> {
         }
     }
 
+    /**
+     * Retrieves a value from the front of the queue.
+     * If the queue is empty, this method waits until a value is added.
+     * @returns A Promise that resolves with the value from the front of the queue.
+     */
     async get(): Promise<T> {
         if (!this.promises.length) {
             this.add();
@@ -44,14 +59,30 @@ export class AsyncQueue<T> {
         });
     }
 
+    /**
+     * Checks if the queue is currently empty.
+     * This checks if there are any resolved or pending promises in the queue.
+     * @returns True if the queue is empty, false otherwise.
+     */
     isEmpty(): boolean {
         return this.promises.length === 0;
     }
 
+    /**
+     * Gets the current number of items in the queue.
+     * This represents the number of promises (resolved or pending) currently held by the queue.
+     * @returns The number of items in the queue.
+     */
     size(): number {
         return this.promises.length;
     }
 
+    /**
+     * Clears all items from the queue.
+     * This removes all pending promises and their resolvers.
+     * Note: This does not explicitly reject pending promises from `get()` calls,
+     * so consumers awaiting `get()` might remain pending indefinitely if not handled.
+     */
     clear(): void {
         // Properly clear the queue by rejecting pending promises to avoid unhandled rejections
         this.resolvers.forEach(resolve => {

--- a/src/frame-msg.ts
+++ b/src/frame-msg.ts
@@ -69,9 +69,14 @@ interface DataResponseSubscriber {
  * Subscribers can register their own handlers for specific message codes.
  */
 export class FrameMsg {
+    /** The underlying {@link FrameBle} instance used for Bluetooth Low Energy communication. */
     public ble: FrameBle;
     private dataResponseHandlers: Map<number, Array<DataResponseSubscriber>>;
 
+    /**
+     * Constructs an instance of the FrameMsg class.
+     * Initializes a new FrameBle instance and sets up internal data response handling.
+     */
     constructor() {
         this.ble = new FrameBle();
         this.dataResponseHandlers = new Map<number, Array<DataResponseSubscriber>>();
@@ -120,21 +125,40 @@ export class FrameMsg {
         }
     }
 
+    /**
+     * Disconnects from the Frame device if currently connected.
+     * @returns A Promise that resolves when disconnection is complete.
+     */
     public async disconnect(): Promise<void> {
         if (this.ble.isConnected()) {
             await this.ble.disconnect();
         }
     }
 
+    /**
+     * Checks if the Frame device is currently connected.
+     * @returns True if connected, false otherwise.
+     */
     public isConnected(): boolean {
         return this.ble.isConnected();
     }
 
+    /**
+     * Displays a short string of text on the Frame's display.
+     * The text is sanitized to escape single quotes and remove newlines.
+     * @param text The text to display. Defaults to an empty string.
+     * @returns A Promise that resolves with the print response from the device if `awaitPrint` is true (default), otherwise void.
+     */
     public async printShortText(text: string = ''): Promise<string | void> {
         const sanitizedText = text.replace(/'/g, "\\'").replace(/\n/g, "");
         return this.ble.sendLua(`frame.display.text('${sanitizedText}',1,1);frame.display.show();print(0)`, { awaitPrint: true });
     }
 
+    /**
+     * Uploads specified standard Lua libraries to the Frame device.
+     * @param libs An array of {@link StdLua} enum values indicating which libraries to upload.
+     * @returns A Promise that resolves when all specified libraries have been uploaded.
+     */
     public async uploadStdLuaLibs(libs: StdLua[]): Promise<void> {
         for (const libKey of libs) {
             const libDetails = standardLuaLibrarySources[libKey];
@@ -146,14 +170,32 @@ export class FrameMsg {
         }
     }
 
+    /**
+     * Uploads a Frame application (Lua script) to the device.
+     * @param fileContent The content of the Lua application file as a string.
+     * @param frameFileName The target filename on the Frame device. Defaults to 'frame_app.lua'.
+     * @returns A Promise that resolves when the file has been uploaded.
+     */
     public async uploadFrameApp(fileContent: string, frameFileName: string = 'frame_app.lua'): Promise<void> {
         await this.ble.uploadFile(fileContent, frameFileName);
     }
 
+    /**
+     * Starts a Frame application on the device by requiring its module name.
+     * @param frameAppName The name of the Frame application module (without .lua extension). Defaults to 'frame_app'.
+     * @param awaitPrint Whether to wait for a print response from the device. Defaults to true.
+     * @returns A Promise that resolves with the print response if `awaitPrint` is true, otherwise void.
+     */
     public async startFrameApp(frameAppName: string = 'frame_app', awaitPrint: boolean = true): Promise<string | void> {
         return this.ble.sendLua(`require('${frameAppName}')`, { awaitPrint: awaitPrint });
     }
 
+    /**
+     * Stops the currently running Frame application by sending a break signal.
+     * Optionally, it can also reset the device.
+     * @param reset If true, sends a reset signal after the break signal. Defaults to true.
+     * @returns A Promise that resolves when the signals have been sent.
+     */
     public async stopFrameApp(reset: boolean = true): Promise<void> {
         await this.ble.sendBreakSignal();
         if (reset) {
@@ -161,14 +203,30 @@ export class FrameMsg {
         }
     }
 
+    /**
+     * Attaches a handler for print responses from the Frame device.
+     * This handler will be called with any text data printed by Lua scripts on the device.
+     * @param handler A function to handle the print response string. Defaults to `console.log`.
+     */
     public attachPrintResponseHandler(handler: (data: string) => void | Promise<void> = console.log): void {
         this.ble.setPrintResponseHandler(handler);
     }
 
+    /**
+     * Detaches the currently set print response handler.
+     * After calling this, print responses from the device will no longer be processed by a custom handler.
+     */
     public detachPrintResponseHandler(): void {
         this.ble.setPrintResponseHandler(undefined);
     }
 
+    /**
+     * Sends a message (msg_code and payload) to the Frame device.
+     * @param msgCode The message code (an integer identifying the message type).
+     * @param payload The Uint8Array payload for the message.
+     * @param showMe If true, prints the message being sent to the console. Defaults to false.
+     * @returns A Promise that resolves when the message has been sent.
+     */
     public async sendMessage(msgCode: number, payload: Uint8Array, showMe: boolean = false): Promise<void> {
         await this.ble.sendMessage(msgCode, payload, showMe);
     }
@@ -194,6 +252,10 @@ export class FrameMsg {
         }
     }
 
+    /**
+     * Unregisters all data response handlers associated with a specific subscriber.
+     * @param subscriber The subscriber object/identifier whose handlers should be removed.
+     */
     public unregisterDataResponseHandler(subscriber: any): void {
         this.dataResponseHandlers.forEach((handlers, code) => {
             const filteredHandlers = handlers.filter(subHandler => subHandler.subscriber !== subscriber);
@@ -229,6 +291,13 @@ export class FrameMsg {
 
     // --- Direct proxy methods to FrameBle for convenience ---
 
+    /**
+     * Sends a Lua command string to the Frame device.
+     * This is a proxy to `FrameBle.sendLua()`.
+     * @param str The Lua command string to send.
+     * @param options Configuration options for sending the Lua command.
+     * @returns A Promise that resolves with the print response if `awaitPrint` is true, otherwise void.
+     */
     public async sendLua(
         str: string,
         options: {
@@ -257,14 +326,32 @@ export class FrameMsg {
         return this.ble.sendData(data, options);
     }
 
+    /**
+     * Sends a reset signal to the Frame device.
+     * This is a proxy to `FrameBle.sendResetSignal()`.
+     * @param showMe If true, prints a message to the console indicating the signal was sent. Defaults to false.
+     * @returns A Promise that resolves when the signal has been sent.
+     */
     public async sendResetSignal(showMe: boolean = false): Promise<void> {
         return this.ble.sendResetSignal(showMe);
     }
 
+    /**
+     * Sends a break signal (Ctrl+C) to the Frame device.
+     * This is a proxy to `FrameBle.sendBreakSignal()`.
+     * @param showMe If true, prints a message to the console indicating the signal was sent. Defaults to false.
+     * @returns A Promise that resolves when the signal has been sent.
+     */
     public async sendBreakSignal(showMe: boolean = false): Promise<void> {
         return this.ble.sendBreakSignal(showMe);
     }
 
+    /**
+     * Gets the maximum payload size for sending data to the Frame device.
+     * This is a proxy to `FrameBle.getMaxPayload()`.
+     * @param isLua True if the payload is for a Lua command, false for other data types.
+     * @returns The maximum payload size in bytes.
+     */
     public getMaxPayload(isLua: boolean): number {
         if (!this.ble) {
             console.warn("FrameBle instance not initialized or not connected for getMaxPayload.");

--- a/src/rx/audio.ts
+++ b/src/rx/audio.ts
@@ -1,25 +1,39 @@
 import { FrameMsg } from '../frame-msg';
 import { AsyncQueue } from '../async-queue';
 
-// enums for sample rate (8000 and 16000 only)
+/**
+ * Defines the supported audio sample rates.
+ */
 export enum RxAudioSampleRate {
+    /** Sample rate of 8000 Hz. */
     SAMPLE_RATE_8KHZ = 8000,
+    /** Sample rate of 16000 Hz. */
     SAMPLE_RATE_16KHZ = 16000,
 }
 
-// enums for bit depth (8 and 16 only)
+/**
+ * Defines the supported audio bit depths.
+ */
 export enum RxAudioBitDepth {
+    /** Bit depth of 8 bits per sample. */
     BIT_DEPTH_8 = 8,
+    /** Bit depth of 16 bits per sample. */
     BIT_DEPTH_16 = 16,
 }
 
-// constructor options
-// now includes sample rate and bit depth
+/**
+ * Configuration options for the RxAudio class.
+ */
 export interface RxAudioOptions {
+    /** Optional flag indicating a non-final audio chunk. Defaults to 0x05. */
     nonFinalChunkFlag?: number;
+    /** Optional flag indicating the final audio chunk. Defaults to 0x06. */
     finalChunkFlag?: number;
+    /** Optional flag to enable streaming mode. Defaults to false (clip mode). */
     streaming?: boolean;
+    /** Optional audio sample rate. Defaults to 8000 Hz. */
     sampleRate?: RxAudioSampleRate;
+    /** Optional audio bit depth. Defaults to 8 bits. */
     bitDepth?: RxAudioBitDepth;
 }
 
@@ -40,9 +54,18 @@ export class RxAudio {
     private bitDepth: number; // 8 or 16
     private sampleRate: RxAudioSampleRate; // 8000 or 16000
 
+    /**
+     * Asynchronous queue for processed audio data chunks.
+     * Each chunk is an Int8Array or Int16Array, or null to signal the end of a stream/clip.
+     */
     public queue: AsyncQueue<Int8Array | Int16Array | null> | null;
-    private _audioBuffer: Uint8Array[]; // Used to accumulate chunks in non-streaming mode
+    /** @internal Buffer to accumulate audio chunks in non-streaming (clip) mode. */
+    private _audioBuffer: Uint8Array[];
 
+    /**
+     * Constructs an instance of the RxAudio class.
+     * @param options Configuration options for the audio handler.
+     */
     constructor(options: RxAudioOptions = {}) {
         this.nonFinalChunkFlag = options.nonFinalChunkFlag ?? 0x05;
         this.finalChunkFlag = options.finalChunkFlag ?? 0x06;
@@ -54,6 +77,11 @@ export class RxAudio {
         this._audioBuffer = [];
     }
 
+    /**
+     * @internal Concatenates all audio chunks in the `_audioBuffer`.
+     * Used in non-streaming mode to assemble the complete audio clip.
+     * @returns A single Uint8Array containing all accumulated audio data.
+     */
     private concatenateAudioData(): Uint8Array {
         let totalLength = 0;
         for (const chunk of this._audioBuffer) {
@@ -68,6 +96,14 @@ export class RxAudio {
         return result;
     }
 
+    /**
+     * Handles incoming raw audio data chunks.
+     * This method is typically called by a `FrameMsg` instance when new audio data is received.
+     * It processes the data based on the configured mode (streaming or clip) and bit depth,
+     * then places the processed audio chunk (Int8Array or Int16Array) onto the `queue`.
+     * A null is placed on the queue to signal the end of a stream or clip.
+     * @param data A Uint8Array containing the raw audio data, prefixed with a flag byte.
+     */
     public handleData(data: Uint8Array): void { //
         if (!this.queue) {
             console.warn("RxAudio: Received data but queue not initialized - call attach() first"); //
@@ -98,6 +134,12 @@ export class RxAudio {
         }
     }
 
+    /**
+     * Attaches this RxAudio instance to a FrameMsg object to receive audio data.
+     * It initializes the audio queue and registers a handler for incoming data.
+     * @param frame The FrameMsg instance to attach to.
+     * @returns A Promise that resolves to the `AsyncQueue` where audio chunks will be placed.
+     */
     public async attach(frame: FrameMsg): Promise<AsyncQueue<Int8Array | Int16Array | null>> {
         this.queue = new AsyncQueue<Int8Array | Int16Array | null>();
         this._audioBuffer = []; // Reset audio buffer
@@ -112,6 +154,11 @@ export class RxAudio {
         return this.queue;
     }
 
+    /**
+     * Detaches this RxAudio instance from a FrameMsg object.
+     * It unregisters the data handler and clears the audio queue.
+     * @param frame The FrameMsg instance to detach from.
+     */
     public detach(frame: FrameMsg): void { //
         // Unsubscribe from the data response feed
         frame.unregisterDataResponseHandler(this); //
@@ -122,12 +169,27 @@ export class RxAudio {
         this._audioBuffer = []; // Reset audio buffer
     }
 
+    /**
+     * @internal Helper function to write a string to a DataView.
+     * Used for constructing WAV file headers.
+     * @param view The DataView to write to.
+     * @param offset The offset at which to start writing.
+     * @param str The string to write.
+     */
     private static writeString(view: DataView, offset: number, str: string): void {
         for (let i = 0; i < str.length; i++) {
             view.setUint8(offset + i, str.charCodeAt(i));
         }
     }
 
+    /**
+     * Converts raw PCM audio data to WAV file format (as a Uint8Array).
+     * @param pcmData The raw PCM data. For 8-bit, assumes signed samples that will be converted to unsigned for WAV.
+     * @param sampleRate The sample rate of the audio (e.g., 8000 Hz). Defaults to 8000.
+     * @param bitsPerSample The number of bits per sample (e.g., 8 or 16). Defaults to 8.
+     * @param channels The number of audio channels (e.g., 1 for mono). Defaults to 1.
+     * @returns A Uint8Array containing the WAV file data.
+     */
     public static toWavBytes(
         pcmData: Uint8Array,
         sampleRate: number = 8000,
@@ -184,7 +246,15 @@ export class RxAudio {
         return new Uint8Array(wavBuffer);
     }
 
-    // --- Helper function to convert signed 8-bit PCM (provided as a raw uint8 array) to Float32Array scaled to [-1.0, 1.0] ---
+    /**
+     * Converts signed 8-bit PCM data (provided as a Uint8Array) to a Float32Array.
+     * The samples are scaled to the range [-1.0, 1.0].
+     * Note: Assumes input samples are signed bytes. Reinterprets Uint8Array as Int8Array.
+     * Samples are scaled by 1/64 (instead of 1/128) and clamped to [-1.0, 1.0]
+     * to account for typical microphone dynamic range usage.
+     * @param pcmData The Uint8Array containing signed 8-bit PCM data.
+     * @returns A Float32Array with samples scaled to [-1.0, 1.0].
+     */
     public static pcm8BitToFloat32(pcmData: Uint8Array) {
         const numSamples = pcmData.length;
         const float32Array = new Float32Array(numSamples);
@@ -207,7 +277,15 @@ export class RxAudio {
         return float32Array;
     }
 
-    // --- Helper function to convert signed 16-bit PCM (provided as a raw uint8 array) to Float32Array scaled to [-1.0, 1.0] ---
+    /**
+     * Converts signed 16-bit PCM data (provided as a Uint8Array) to a Float32Array.
+     * The samples are scaled to the range [-1.0, 1.0].
+     * Note: Assumes input Uint8Array contains little-endian signed 16-bit samples.
+     * Samples are scaled by 1/16384 (instead of 1/32768) and clamped to [-1.0, 1.0]
+     * to account for typical microphone dynamic range usage.
+     * @param pcmData The Uint8Array containing signed 16-bit PCM data (little-endian).
+     * @returns A Float32Array with samples scaled to [-1.0, 1.0].
+     */
     public static pcm16BitToFloat32(pcmData: Uint8Array) {
         const numSamples = pcmData.length / 2;
         const float32Array = new Float32Array(numSamples);

--- a/src/rx/auto-exp-result.ts
+++ b/src/rx/auto-exp-result.ts
@@ -5,9 +5,13 @@ import { AsyncQueue } from '../async-queue';
  * Interface for the detailed brightness metrics (matrix or spot).
  */
 export interface BrightnessDetails {
+    /** Red channel brightness component. */
     r: number;
+    /** Green channel brightness component. */
     g: number;
+    /** Blue channel brightness component. */
     b: number;
+    /** Average brightness across R, G, B channels. */
     average: number;
 }
 
@@ -15,9 +19,13 @@ export interface BrightnessDetails {
  * Interface for the overall brightness data structure.
  */
 export interface BrightnessData {
+    /** Center-weighted average brightness of the scene. */
     center_weighted_average: number;
+    /** Overall scene brightness. */
     scene: number;
+    /** Detailed brightness metrics using matrix metering. */
     matrix: BrightnessDetails;
+    /** Detailed brightness metrics using spot metering. */
     spot: BrightnessDetails;
 }
 
@@ -25,12 +33,19 @@ export interface BrightnessData {
  * Interface for the structured auto exposure result data.
  */
 export interface AutoExpResultData {
+    /** The error value from the auto exposure algorithm. */
     error: number;
+    /** The calculated shutter speed (exposure time). */
     shutter: number;
+    /** The calculated analog gain. */
     analog_gain: number;
+    /** The red channel gain. */
     red_gain: number;
+    /** The green channel gain. */
     green_gain: number;
+    /** The blue channel gain. */
     blue_gain: number;
+    /** Detailed brightness data used for auto exposure. */
     brightness: BrightnessData;
 }
 
@@ -38,6 +53,7 @@ export interface AutoExpResultData {
  * Options for RxAutoExpResult constructor.
  */
 export interface RxAutoExpResultOptions {
+    /** Optional message code to identify auto exposure result packets. Defaults to 0x11. */
     msgCode?: number;
 }
 
@@ -46,6 +62,7 @@ export interface RxAutoExpResultOptions {
  */
 export class RxAutoExpResult {
     private msgCode: number;
+    /** Asynchronous queue for received auto exposure result data. Null if not attached. */
     public queue: AsyncQueue<AutoExpResultData | null> | null;
 
     /**

--- a/src/rx/imu.ts
+++ b/src/rx/imu.ts
@@ -49,28 +49,43 @@ class SensorBuffer {
  * Interface for raw IMU data.
  */
 export interface IMURawData {
+    /** Raw compass data as a tuple: `[x, y, z]`. */
     compass: [number, number, number];
+    /** Raw accelerometer data as a tuple: `[x, y, z]`. */
     accel: [number, number, number];
 }
 
 /**
  * Class for processed IMU data.
+ * Contains smoothed compass and accelerometer data, and optionally the raw data.
+ * Also provides calculated pitch and roll values.
  */
 export class IMUData {
+    /** Smoothed compass data as a tuple: `[x, y, z]`. */
     public compass: [number, number, number];
+    /** Smoothed accelerometer data as a tuple: `[x, y, z]`. */
     public accel: [number, number, number];
+    /** Optional raw IMU data. */
     public raw?: IMURawData;
 
+    /**
+     * Constructs an instance of IMUData.
+     * @param compass Smoothed compass data `[x, y, z]`.
+     * @param accel Smoothed accelerometer data `[x, y, z]`.
+     * @param raw Optional raw IMU data.
+     */
     constructor(compass: [number, number, number], accel: [number, number, number], raw?: IMURawData) {
         this.compass = compass;
         this.accel = accel;
         this.raw = raw;
     }
 
+    /** Calculated pitch in degrees. */
     public get pitch(): number {
         return Math.atan2(this.accel[1], this.accel[2]) * 180.0 / Math.PI;
     }
 
+    /** Calculated roll in degrees. */
     public get roll(): number {
         return Math.atan2(this.accel[0], this.accel[2]) * 180.0 / Math.PI;
     }
@@ -80,7 +95,9 @@ export class IMUData {
  * Options for RxIMU constructor.
  */
 export interface RxIMUOptions {
+    /** Optional flag to identify IMU data packets. Defaults to 0x0A. */
     imuFlag?: number;
+    /** Optional number of samples to average for smoothing. Defaults to 1 (no smoothing). */
     smoothingSamples?: number;
 }
 
@@ -92,10 +109,15 @@ export class RxIMU {
     private imuFlag: number;
     private smoothingSamples: number;
 
+    /** Asynchronous queue for received IMUData objects. Null if not attached. */
     public queue: AsyncQueue<IMUData | null> | null;
     private compassBuffer: SensorBuffer;
     private accelBuffer: SensorBuffer;
 
+    /**
+     * Constructs an instance of the RxIMU class.
+     * @param options Configuration options for the IMU handler.
+     */
     constructor(options: RxIMUOptions = {}) {
         this.imuFlag = options.imuFlag ?? 0x0A; //
         this.smoothingSamples = options.smoothingSamples ?? 1; //

--- a/src/rx/metering-data.ts
+++ b/src/rx/metering-data.ts
@@ -5,11 +5,17 @@ import { AsyncQueue } from '../async-queue';
  * Interface for the structured metering data.
  */
 export interface MeteringData {
+    /** Spot metering red channel value. */
     spot_r: number;
+    /** Spot metering green channel value. */
     spot_g: number;
+    /** Spot metering blue channel value. */
     spot_b: number;
+    /** Matrix metering red channel value. */
     matrix_r: number;
+    /** Matrix metering green channel value. */
     matrix_g: number;
+    /** Matrix metering blue channel value. */
     matrix_b: number;
 }
 
@@ -17,6 +23,7 @@ export interface MeteringData {
  * Options for RxMeteringData constructor.
  */
 export interface RxMeteringDataOptions {
+    /** Optional message code to identify metering data packets. Defaults to 0x12. */
     msgCode?: number;
 }
 
@@ -25,8 +32,13 @@ export interface RxMeteringDataOptions {
  */
 export class RxMeteringData {
     private msgCode: number;
+    /** Asynchronous queue for received MeteringData objects. Null if not attached. */
     public queue: AsyncQueue<MeteringData | null> | null;
 
+    /**
+     * Constructs an instance of the RxMeteringData class.
+     * @param options Configuration options for the metering data handler.
+     */
     constructor(options: RxMeteringDataOptions = {}) {
         this.msgCode = options.msgCode ?? 0x12; // Default msg_code from Python
         this.queue = null;

--- a/src/tx/auto-exp-settings.ts
+++ b/src/tx/auto-exp-settings.ts
@@ -1,4 +1,24 @@
 /**
+ * Options for configuring auto exposure and gain settings.
+ */
+export interface TxAutoExpSettingsOptions {
+    /** Optional zero-based index into metering modes ['SPOT', 'CENTER_WEIGHTED', 'AVERAGE'] (0, 1, or 2). Defaults to 1 (CENTER_WEIGHTED). */
+    meteringIndex?: number;
+    /** Optional target exposure value (0.0-1.0). Defaults to 0.1. */
+    exposure?: number;
+    /** Optional speed of exposure adjustments (0.0-1.0). Defaults to 0.45. */
+    exposureSpeed?: number;
+    /** Optional maximum shutter value (4-16383). Defaults to 16383. */
+    shutterLimit?: number;
+    /** Optional maximum analog gain value (1-248). Defaults to 16. */
+    analogGainLimit?: number;
+    /** Optional speed of white balance adjustments (0.0-1.0). Defaults to 0.5. */
+    whiteBalanceSpeed?: number;
+    /** Optional maximum gain value for red, green, blue channels (0-1023). Defaults to 287. */
+    rgbGainLimit?: number;
+}
+
+/**
  * Message for auto exposure and gain settings.
  */
 export class TxAutoExpSettings {
@@ -32,30 +52,17 @@ export class TxAutoExpSettings {
     public rgbGainLimit: number;
 
     /**
-     * @param meteringIndex Zero-based index into ['SPOT', 'CENTER_WEIGHTED', 'AVERAGE']. Defaults to 1.
-     * @param exposure Target exposure value (0.0-1.0). Defaults to 0.1.
-     * @param exposureSpeed Speed of exposure adjustments (0.0-1.0). Defaults to 0.45.
-     * @param shutterLimit Maximum shutter value (4-16383). Defaults to 16383.
-     * @param analogGainLimit Maximum analog gain value (1-248). Defaults to 16.
-     * @param whiteBalanceSpeed Speed of white balance adjustments (0.0-1.0). Defaults to 0.5.
-     * @param rgbGainLimit Maximum gain value for red, green, blue channels (0-1023). Defaults to 287.
+     * Constructs an instance of TxAutoExpSettings.
+     * @param options Configuration options for auto exposure and gain settings.
      */
-    constructor(
-        meteringIndex: number = 1,
-        exposure: number = 0.1,
-        exposureSpeed: number = 0.45,
-        shutterLimit: number = 16383,
-        analogGainLimit: number = 16,
-        whiteBalanceSpeed: number = 0.5,
-        rgbGainLimit: number = 287
-    ) {
-        this.meteringIndex = meteringIndex;
-        this.exposure = exposure;
-        this.exposureSpeed = exposureSpeed;
-        this.shutterLimit = shutterLimit;
-        this.analogGainLimit = analogGainLimit;
-        this.whiteBalanceSpeed = whiteBalanceSpeed;
-        this.rgbGainLimit = rgbGainLimit;
+    constructor(options: TxAutoExpSettingsOptions = {}) {
+        this.meteringIndex = options.meteringIndex ?? 1;
+        this.exposure = options.exposure ?? 0.1;
+        this.exposureSpeed = options.exposureSpeed ?? 0.45;
+        this.shutterLimit = options.shutterLimit ?? 16383;
+        this.analogGainLimit = options.analogGainLimit ?? 16;
+        this.whiteBalanceSpeed = options.whiteBalanceSpeed ?? 0.5;
+        this.rgbGainLimit = options.rgbGainLimit ?? 287;
     }
 
     /**

--- a/src/tx/capture-settings.ts
+++ b/src/tx/capture-settings.ts
@@ -1,4 +1,18 @@
 /**
+ * Options for configuring camera capture settings.
+ */
+export interface TxCaptureSettingsOptions {
+    /** Optional image resolution (256-720, must be even). Defaults to 512. */
+    resolution?: number;
+    /** Optional index into JPEG quality array [VERY_LOW, LOW, MEDIUM, HIGH, VERY_HIGH] (0-4). Defaults to 4 (VERY_HIGH). */
+    qualityIndex?: number;
+    /** Optional image pan value (-140 to 140). Defaults to 0. */
+    pan?: number;
+    /** Optional flag whether to capture in RAW (headerless JPEG) format. Defaults to false. */
+    raw?: boolean;
+}
+
+/**
  * Message for camera capture settings.
  */
 export class TxCaptureSettings {
@@ -20,21 +34,14 @@ export class TxCaptureSettings {
     public raw: boolean;
 
     /**
-     * @param resolution Image resolution (256-720, must be even). Defaults to 512.
-     * @param qualityIndex Index into [VERY_LOW, LOW, MEDIUM, HIGH, VERY_HIGH]. Defaults to 4.
-     * @param pan Image pan value (-140 to 140). Defaults to 0.
-     * @param raw Whether to return the JPEG in raw (headerless) format. Defaults to false.
+     * Constructs an instance of TxCaptureSettings.
+     * @param options Configuration options for the capture settings.
      */
-    constructor(
-        resolution: number = 512,
-        qualityIndex: number = 4,
-        pan: number = 0,
-        raw: boolean = false
-    ) {
-        this.resolution = resolution;
-        this.qualityIndex = qualityIndex;
-        this.pan = pan;
-        this.raw = raw;
+    constructor(options: TxCaptureSettingsOptions = {}) {
+        this.resolution = options.resolution ?? 512;
+        this.qualityIndex = options.qualityIndex ?? 4;
+        this.pan = options.pan ?? 0;
+        this.raw = options.raw ?? false;
     }
 
     /**

--- a/src/tx/code.ts
+++ b/src/tx/code.ts
@@ -1,14 +1,25 @@
 /**
+ * Options for configuring a TxCode message.
+ */
+export interface TxCodeOptions {
+    /** Optional byte value to be transmitted (0-255). Defaults to 0. */
+    value?: number;
+}
+
+/**
  * A simple message containing only a message code and an optional byte value.
  * Used for signaling the frameside app to take some action.
  */
 export class TxCode {
+    public value: number;
+
     /**
-     * @param value The byte value to be transmitted (0-255)
+     * Constructs an instance of TxCode.
+     * @param options Configuration options for the code message.
      */
-    constructor(
-        public value: number = 0
-    ) {}
+    constructor(options: TxCodeOptions = {}) {
+        this.value = options.value ?? 0;
+    }
 
     /**
      * Packs the message into a single byte.

--- a/src/tx/manual-exp-settings.ts
+++ b/src/tx/manual-exp-settings.ts
@@ -1,4 +1,20 @@
 /**
+ * Options for configuring manual exposure and gain settings.
+ */
+export interface TxManualExpSettingsOptions {
+    /** Optional shutter value (4-16383). Defaults to 3072. */
+    manualShutter?: number;
+    /** Optional analog gain value (1-248). Defaults to 16. */
+    manualAnalogGain?: number;
+    /** Optional red gain value (0-1023). Defaults to 121. */
+    manualRedGain?: number;
+    /** Optional green gain value (0-1023). Defaults to 64. */
+    manualGreenGain?: number;
+    /** Optional blue gain value (0-1023). Defaults to 140. */
+    manualBlueGain?: number;
+}
+
+/**
  * Message for manual exposure and gain settings.
  */
 export class TxManualExpSettings {
@@ -24,24 +40,15 @@ export class TxManualExpSettings {
     public manualBlueGain: number;
 
     /**
-     * @param manualShutter Shutter value (4-16383). Defaults to 3072.
-     * @param manualAnalogGain Analog gain value (1-248). Defaults to 16.
-     * @param manualRedGain Red gain value (0-1023). Defaults to 121.
-     * @param manualGreenGain Green gain value (0-1023). Defaults to 64.
-     * @param manualBlueGain Blue gain value (0-1023). Defaults to 140.
+     * Constructs an instance of TxManualExpSettings.
+     * @param options Configuration options for manual exposure and gain settings.
      */
-    constructor(
-        manualShutter: number = 3072,
-        manualAnalogGain: number = 16,
-        manualRedGain: number = 121,
-        manualGreenGain: number = 64,
-        manualBlueGain: number = 140
-    ) {
-        this.manualShutter = manualShutter;
-        this.manualAnalogGain = manualAnalogGain;
-        this.manualRedGain = manualRedGain;
-        this.manualGreenGain = manualGreenGain;
-        this.manualBlueGain = manualBlueGain;
+    constructor(options: TxManualExpSettingsOptions = {}) {
+        this.manualShutter = options.manualShutter ?? 3072;
+        this.manualAnalogGain = options.manualAnalogGain ?? 16;
+        this.manualRedGain = options.manualRedGain ?? 121;
+        this.manualGreenGain = options.manualGreenGain ?? 64;
+        this.manualBlueGain = options.manualBlueGain ?? 140;
     }
 
     /**

--- a/src/tx/plain-text.ts
+++ b/src/tx/plain-text.ts
@@ -1,21 +1,40 @@
 /**
+ * Options for configuring a plain text message.
+ */
+export interface TxPlainTextOptions {
+    /** The plain text content to be transmitted. */
+    text: string;
+    /** Optional X-coordinate for text position (1-640, Lua/1-based indexing). Defaults to 1. */
+    x?: number;
+    /** Optional Y-coordinate for text position (1-400, Lua/1-based indexing). Defaults to 1. */
+    y?: number;
+    /** Optional color palette offset (1-15, 0/'VOID' is invalid). Defaults to 1. */
+    paletteOffset?: number;
+    /** Optional character spacing value. Defaults to 4. */
+    spacing?: number;
+}
+
+/**
  * A message containing plain text with positioning and formatting information.
  */
 export class TxPlainText {
+    public text: string;
+    public x: number;
+    public y: number;
+    public paletteOffset: number;
+    public spacing: number;
+
     /**
-     * @param text The plain text content to be transmitted
-     * @param x X-coordinate for text position (1-640, Lua/1-based indexing)
-     * @param y Y-coordinate for text position (1-400, Lua/1-based indexing)
-     * @param paletteOffset Color palette offset (1-15, 0/'VOID' is invalid)
-     * @param spacing Character spacing value
+     * Constructs an instance of TxPlainText.
+     * @param options Configuration options for the plain text message.
      */
-    constructor(
-        public text: string,
-        public x: number = 1,
-        public y: number = 1,
-        public paletteOffset: number = 1,
-        public spacing: number = 4
-    ) {}
+    constructor(options: TxPlainTextOptions) {
+        this.text = options.text;
+        this.x = options.x ?? 1;
+        this.y = options.y ?? 1;
+        this.paletteOffset = options.paletteOffset ?? 1;
+        this.spacing = options.spacing ?? 4;
+    }
 
     /**
      * Packs the message into a binary format.

--- a/src/tx/sprite-coords.ts
+++ b/src/tx/sprite-coords.ts
@@ -1,4 +1,18 @@
 /**
+ * Options for configuring sprite coordinates.
+ */
+export interface TxSpriteCoordsOptions {
+    /** Unsigned byte identifying the sprite code. */
+    code: number;
+    /** X-coordinate for sprite position (1-640). */
+    x: number;
+    /** Y-coordinate for sprite position (1-400). */
+    y: number;
+    /** Optional palette offset value for the sprite (0-15). Defaults to 0. */
+    offset?: number;
+}
+
+/**
  * A message containing sprite coordinates information for display.
  */
 export class TxSpriteCoords {
@@ -20,21 +34,14 @@ export class TxSpriteCoords {
     public offset: number;
 
     /**
-     * @param code Unsigned byte identifying the sprite code.
-     * @param x X-coordinate for sprite position (1..640).
-     * @param y Y-coordinate for sprite position (1..400).
-     * @param offset Palette offset value for the sprite (0..15). Defaults to 0.
+     * Constructs an instance of TxSpriteCoords.
+     * @param options Configuration options for the sprite coordinates.
      */
-    constructor(
-        code: number,
-        x: number,
-        y: number,
-        offset: number = 0
-    ) {
-        this.code = code;
-        this.x = x;
-        this.y = y;
-        this.offset = offset;
+    constructor(options: TxSpriteCoordsOptions) {
+        this.code = options.code;
+        this.x = options.x;
+        this.y = options.y;
+        this.offset = options.offset ?? 0;
     }
 
     /**

--- a/src/tx/text-sprite-block.ts
+++ b/src/tx/text-sprite-block.ts
@@ -149,14 +149,14 @@ export class TxTextSpriteBlock {
                     spritePixelData[j] = (croppedData[i] > 127) ? 1 : 0;
                 }
 
-                const textLineSprite = new TxSprite(
-                    finalSpriteWidth,
-                    finalSpriteHeight,
-                    2,
-                    new Uint8Array([0, 0, 0, 255, 255, 255]),
-                    spritePixelData,
-                    false
-                );
+                const textLineSprite = new TxSprite({
+                    width: finalSpriteWidth,
+                    height: finalSpriteHeight,
+                    numColors: 2,
+                    paletteData: new Uint8Array([0, 0, 0, 255, 255, 255]),
+                    pixelData: spritePixelData,
+                    compress: false
+            });
                 this.sprites.push(textLineSprite);
             }
         }

--- a/src/tx/text-sprite-block.ts
+++ b/src/tx/text-sprite-block.ts
@@ -20,12 +20,18 @@ export interface TxTextSpriteBlockOptions {
  * A block of text rendered as sprites, for use in a browser environment.
  */
 export class TxTextSpriteBlock {
+    /** The width constraint for the text layout, in pixels. */
     public width: number;
+    /** The font size used for rendering the text, in pixels. */
     public fontSize: number;
+    /** The maximum number of rows of text to be displayed. */
     public maxDisplayRows: number;
+    /** The raw text content to be rendered. */
     public text: string;
+    /** The font family used for rendering the text. */
     public fontFamily: string;
 
+    /** An array of {@link TxSprite} instances, each representing a line of rendered text. */
     public sprites: TxSprite[] = [];
 
     /**


### PR DESCRIPTION
- Breaking: convert all Tx/Rx class constructors to use options objects for all parameters
- Add TypeDoc comments to all external library functions, plus example run() functions